### PR TITLE
go install after go build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ You can decide to do one of two things:
 ```
 $ git clone https://github.com/olumidayy/go-github.git
 ```
- After cloning, you can then build the tool by running:
+ After cloning go-github, build the tool by running:
  ```
  $ go build
+ 
+ ```
+ Then add go-github to your Go binaries using the `install` command.
+ 
+ ```
  $ go install
  ```
+ 
 - Or just install tool directly in your project.
 ```
 $ go install github.com/olumidayy/go-github@latest

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ git clone https://github.com/olumidayy/go-github.git
  After cloning, you can then build the tool by running:
  ```
  $ go build
+ $ go install
  ```
 - Or just install tool directly in your project.
 ```


### PR DESCRIPTION
Go build only builds the executable, they'll have to install it in their binary folder (bin)

That's why they need to use go install.